### PR TITLE
chore: update json5 transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7006,9 +7006,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -9055,9 +9055,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -15085,9 +15085,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -16577,9 +16577,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"


### PR DESCRIPTION
## Description
updates json5 transitive dependency.
Steps to get to this:
- clone repo
- run `npm install`
- run `npm audit fix`

I started this PR based on message encountered running `npm install`. The message was about a vulnerability in json5 module, and suggested running `npm audit fix`
- there had been multiple transitive dependencies on json5 and this changes
the version number of them

<!-- What does this code change? Why did I choose this approach? Did I 
learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
N/A
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|  x  | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
N/A
<!-- If UI feature, take provide screenshots -->

### After
N/A
<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
N/A
<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

