### PR TITLE
Fixes: alert to toaster & AddItem bug

### DIFF
--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,5 +1,6 @@
 import { addItem } from '../api/firebase';
 import { useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
 
 /**
  * Allows user to add an item to their shopping list,
@@ -11,8 +12,16 @@ export function AddItem({ listToken }) {
 	// declare itemName, daysUntilNextPurchase, and radioSelect
 	// into separate state variables
 	const [itemName, setItemName] = useState('');
-
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
+
+	// react-hot-toast utilized for notifications
+	// Notify when adding item is unsuccessful:
+	const notifyFailedRequest = () => toast.error('Failed to add item');
+
+	// Notify when adding item is successful:
+	const notifyItemAdded = (itemName) => {
+		toast.success(`${itemName} was added to your list`);
+	};
 
 	// Store values inside itemData and sent over to database
 	// otherwise log an error if request fails
@@ -25,9 +34,9 @@ export function AddItem({ listToken }) {
 		try {
 			addItem(listToken, itemData);
 			setItemName('');
-			alert(`${itemData.itemName} was added to your list`);
+			notifyItemAdded(itemData.itemName);
 		} catch (error) {
-			console.log(error);
+			notifyFailedRequest();
 		}
 	};
 
@@ -43,54 +52,57 @@ export function AddItem({ listToken }) {
 	};
 
 	return (
-		<form onSubmit={onFormSubmit}>
-			<div>
-				<label htmlFor="item">Item Name:</label>
-			</div>
-			<input
-				type="text"
-				id="item"
-				name="item"
-				value={itemName}
-				onChange={(event) => setItemName(event.target.value)}
-				required={true}
-			/>
-			<div id="purchase-date-label">How soon will you buy this again?</div>
-			<fieldset>
+		<>
+			<form onSubmit={onFormSubmit}>
 				<div>
-					<input
-						defaultChecked
-						aria-labelledby="purchase-date-label"
-						type="radio"
-						value="soon"
-						id="soon"
-						name="radio-btn"
-						onChange={handlePurchaseDate}
-					/>
-					<label htmlFor="soon">Soon</label>
+					<label htmlFor="item">Item Name:</label>
 				</div>
-				<div>
-					<input
-						type="radio"
-						value="kind-of-soon"
-						id="kind-of-soon"
-						name="radio-btn"
-						onChange={handlePurchaseDate}
-					/>
-					<label htmlFor="kind-of-soon">Kind Of Soon</label>
-				</div>
-				<div>
-					<input
-						type="radio"
-						id="not-soon"
-						value="not-soon"
-						name="radio-btn"
-						onChange={handlePurchaseDate}
-					/>
-					<label htmlFor="not-soon">Not Soon</label>
-				</div>
-			</fieldset>
-			<button type="submit">Add Item</button>
-		</form>
+				<input
+					type="text"
+					id="item"
+					name="item"
+					value={itemName}
+					onChange={(event) => setItemName(event.target.value)}
+					required={true}
+				/>
+				<div id="purchase-date-label">How soon will you buy this again?</div>
+				<fieldset>
+					<div>
+						<input
+							defaultChecked
+							aria-labelledby="purchase-date-label"
+							type="radio"
+							value="soon"
+							id="soon"
+							name="radio-btn"
+							onChange={handlePurchaseDate}
+						/>
+						<label htmlFor="soon">Soon</label>
+					</div>
+					<div>
+						<input
+							type="radio"
+							value="kind-of-soon"
+							id="kind-of-soon"
+							name="radio-btn"
+							onChange={handlePurchaseDate}
+						/>
+						<label htmlFor="kind-of-soon">Kind Of Soon</label>
+					</div>
+					<div>
+						<input
+							type="radio"
+							id="not-soon"
+							value="not-soon"
+							name="radio-btn"
+							onChange={handlePurchaseDate}
+						/>
+						<label htmlFor="not-soon">Not Soon</label>
+					</div>
+				</fieldset>
+				<button type="submit">Add Item</button>
+			</form>
+			<Toaster />
+		</>
 	);
 }

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -14,11 +14,15 @@ export function AddItem({ listToken }) {
 	const [itemName, setItemName] = useState('');
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 
-	// react-hot-toast utilized for notifications
-	// Notify when adding item is unsuccessful:
+	// react-hot-toast notifications:
+
+	// Notify when adding item is unsuccessful
 	const notifyFailedRequest = () => toast.error('Failed to add item');
 
-	// Notify when adding item is successful:
+	// Notify when adding item but there's no list token
+	const notifyNoToken = () => toast.error('Please add a list token first');
+
+	// Notify when adding item is successful
 	const notifyItemAdded = (itemName) => {
 		toast.success(`${itemName} was added to your list`);
 	};
@@ -27,6 +31,13 @@ export function AddItem({ listToken }) {
 	// otherwise log an error if request fails
 	const onFormSubmit = (event) => {
 		event.preventDefault();
+
+		// if list token is not provided, notify user and exit function
+		if (!listToken) {
+			notifyNoToken();
+			return;
+		}
+
 		const itemData = {
 			itemName,
 			daysUntilNextPurchase,


### PR DESCRIPTION
## Description

Fixes:
- When there’s no token on input, an item can still be added causing a Firestore error. To fix this, a conditional is added in `onFormSubmit` to check for a token and send an error notification.
- The previous alert when adding an item has been updated to `Toaster`.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
#4

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![after-add-item-to-list](https://user-images.githubusercontent.com/102492480/215253178-e0c8aa69-77fd-4861-ad3c-1ffe237610ee.gif)

### After
![toaster](https://user-images.githubusercontent.com/102492480/215253426-f92da737-2a30-43ff-83c5-90354d986aa4.gif)