### PR TITLE
issue #12 | Sorting items in list by purchase urgency

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -35,35 +35,48 @@ export function streamListItems(listId, handleSuccess) {
  * sorts items in ascending order of days until purchase, and
  * sorts items with the same days until purchase alphabetically
  */
-export function comparePurchaseUrgency(dateNextPurchased) {
-	//take in an item value for date next purchased
 
-	//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
-	const currentDate = new Date();
-	const daysSinceLastPurchased = getDaysBetweenDates(
-		currentDate,
-		dateNextPurchased.toDate(),
-	);
-	console.log('Days since last purchased = ', daysSinceLastPurchased);
-	let buyingUrgency;
-
-	//if else statement to declare which of the 4 possible groups of urgency it belongs to
-	if (daysSinceLastPurchased <= 7) {
-		buyingUrgency = 'soon (7 days or less)';
-	} else if (7 < daysSinceLastPurchased < 30) {
-		buyingUrgency = 'kind of soon (30 days or less)';
-	} else if (daysSinceLastPurchased >= 30) {
-		buyingUrgency = 'not soon (more than 30 days)';
-	} else if (30 < daysSinceLastPurchased < 60) {
-		buyingUrgency = 'overdue for purchase';
+//TODO: include sort for inactive items last
+// IT DOES:  - sort to most urgent date next pruchased
+// 			 - sorts to earliest alphabet name if date next purchased is the same
+export function comparePurchaseUrgency(item1, item2) {
+	if (item1.dateNextPurchased.toDate() < item2.dateNextPurchased.toDate()) {
+		return -1;
+	} else if (
+		item1.dateNextPurchased.toDate() > item2.dateNextPurchased.toDate()
+	) {
+		return 1;
 	} else {
-		buyingUrgency = 'inactive (has not been purchased recently)';
+		if (item1.name < item2.name) {
+			return -1;
+		} else {
+			return 1;
+		}
 	}
-
-	//return urgency value
-
-	return buyingUrgency;
 }
+
+//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
+// const daysSinceLastPurchased = getDaysBetweenDates(
+// 	currentDate,
+// 	item.dateNextPurchased.toDate(),
+// );
+// console.log(daysSinceLastPurchased);
+// let buyingUrgency;
+
+//if else statement to declare which of the 4 possible groups of urgency it belongs to
+// if (daysSinceLastPurchased <= 7) {
+// 	buyingUrgency = 'soon (7 days or less)';
+// } else if (7 < daysSinceLastPurchased < 30) {
+// 	buyingUrgency = 'kind of soon (30 days or less)';
+// } else if (daysSinceLastPurchased >= 30) {
+// 	buyingUrgency = 'not soon (more than 30 days)';
+// } else if (30 < daysSinceLastPurchased < 60) {
+// 	buyingUrgency = 'overdue for purchase';
+// } else {
+// 	buyingUrgency = 'inactive (has not been purchased recently)';
+// }
+
+//return urgency value
 
 /**
  * Read the information from the provided snapshot and return an array

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -39,41 +39,27 @@ export function streamListItems(listId, handleSuccess) {
  * - sorts for overdue items to be listed at the top that aren't inactive
  */
 export function comparePurchaseUrgency(item1, item2) {
-	//find the difference between the current date and next purchase date
-	const daysUntilNextPurchaseItem1 = getDaysBetweenDates(
-		new Date(),
-		item1.dateNextPurchased.toDate(),
-	);
-
-	//refactor test
-	// function daysUntilNextPurchase(item){
-	// 	return getDaysBetweenDates(
-	// 		new Date(),
-	// 		(item).dateNextPurchased.toDate(),
-	// 	)
-	// }
-
-	const daysUntilNextPurchaseItem2 = getDaysBetweenDates(
-		new Date(),
-		item2.dateNextPurchased.toDate(),
-	);
-
-	//Inactive item conditional
-	if (daysUntilNextPurchaseItem1 >= 60) {
-		return 1;
+	//gets the days until next purchase between current date and dateNextPurchased for item argument
+	function getDaysUntilNextPurchase(item) {
+		return getDaysBetweenDates(new Date(), item.dateNextPurchased.toDate());
 	}
 
+	//Inactive item conditional
+	if (getDaysUntilNextPurchase(item1) >= 60) {
+		return 1;
+	}
 	//Overdue item conditional
 	if (new Date() > item1.dateNextPurchased.toDate()) {
 		return -1;
 	} else if (new Date() > item2.dateNextPurchased.toDate()) {
 		return 1;
 	}
-
 	//Conditionals for days until next purchase and alphabetized if same number of days
-	if (daysUntilNextPurchaseItem1 < daysUntilNextPurchaseItem2) {
+	if (getDaysUntilNextPurchase(item1) < getDaysUntilNextPurchase(item2)) {
 		return -1;
-	} else if (daysUntilNextPurchaseItem1 > daysUntilNextPurchaseItem2) {
+	} else if (
+		getDaysUntilNextPurchase(item1) > getDaysUntilNextPurchase(item2)
+	) {
 		return 1;
 	} else {
 		if (item1.name < item2.name) {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -30,29 +30,37 @@ export function streamListItems(listId, handleSuccess) {
 }
 
 /**
- * comparePurchaseUrgency
- * sorts inactive items last, then
- * sorts items in ascending order of days until purchase, and
- * sorts items with the same days until purchase alphabetically
+ * comparePurchaseUrgency CURRENT FUNCTIONS:
+ * - sort for inactive items last, then
+ * - sort to most urgent date next pruchased, then
+ * - sorts to earliest alphabet name if date next purchased is the same
+ *
+ * TODO (STRETCH GOAL):
+ * - sorts for overdue items to be listed at the top that aren't inactive
  */
-
-// IT DOES:  - sort for inactive items last, then
-//			 - sort to most urgent date next pruchased, then
-// 			 - sorts to earliest alphabet name if date next purchased is the same
 export function comparePurchaseUrgency(item1, item2) {
-	//inactive items got last immediately
-	const daysSinceLastPurchasedItem1 = getDaysBetweenDates(
+	//find the difference between the current date and next purchase date
+	const daysUntilNextPurchaseItem1 = getDaysBetweenDates(
 		new Date(),
 		item1.dateNextPurchased.toDate(),
 	);
 
-	if (daysSinceLastPurchasedItem1 >= 60) {
+	//TODO: can this be simplified/is this the right logic direction?
+	let daysSinceLastPurchaseItem1 = item1.dateLastPurchased
+		? getDaysBetweenDates(new Date(), item1.dateLastPurchased.toDate())
+		: item1.dateLastPurchased;
+
+	//Inactive item conditional
+	if (daysUntilNextPurchaseItem1 >= 60) {
 		return 1;
 	}
-	// if (daysSinceLastPurchasedItem1 < 60 && daysSinceLastPurchasedItem1 > 30) {
+
+	//TODO: overdue item conditional goes here
+	// if (daysUntilNextPurchaseItem1 < 60 && daysSinceLastPurchaseItem1 > 0) {
 	// 	return -1;
 	// }
 
+	//Conditionals for days until next purchase and alphabetized if same number of days
 	if (item1.dateNextPurchased.toDate() < item2.dateNextPurchased.toDate()) {
 		return -1;
 	} else if (

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -45,27 +45,35 @@ export function comparePurchaseUrgency(item1, item2) {
 		item1.dateNextPurchased.toDate(),
 	);
 
-	//TODO: can this be simplified/is this the right logic direction?
-	let daysSinceLastPurchaseItem1 = item1.dateLastPurchased
-		? getDaysBetweenDates(new Date(), item1.dateLastPurchased.toDate())
-		: item1.dateLastPurchased;
+	//refactor test
+	// function daysUntilNextPurchase(item){
+	// 	return getDaysBetweenDates(
+	// 		new Date(),
+	// 		(item).dateNextPurchased.toDate(),
+	// 	)
+	// }
+
+	const daysUntilNextPurchaseItem2 = getDaysBetweenDates(
+		new Date(),
+		item2.dateNextPurchased.toDate(),
+	);
 
 	//Inactive item conditional
 	if (daysUntilNextPurchaseItem1 >= 60) {
 		return 1;
 	}
 
-	//TODO: overdue item conditional goes here
-	// if (daysUntilNextPurchaseItem1 < 60 && daysSinceLastPurchaseItem1 > 0) {
-	// 	return -1;
-	// }
+	//Overdue item conditional
+	if (new Date() > item1.dateNextPurchased.toDate()) {
+		return -1;
+	} else if (new Date() > item2.dateNextPurchased.toDate()) {
+		return 1;
+	}
 
 	//Conditionals for days until next purchase and alphabetized if same number of days
-	if (item1.dateNextPurchased.toDate() < item2.dateNextPurchased.toDate()) {
+	if (daysUntilNextPurchaseItem1 < daysUntilNextPurchaseItem2) {
 		return -1;
-	} else if (
-		item1.dateNextPurchased.toDate() > item2.dateNextPurchased.toDate()
-	) {
+	} else if (daysUntilNextPurchaseItem1 > daysUntilNextPurchaseItem2) {
 		return 1;
 	} else {
 		if (item1.name < item2.name) {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -37,9 +37,12 @@ export function streamListItems(listId, handleSuccess) {
  * - sort to earliest alphabet name if date next purchased is the same
  */
 export function comparePurchaseUrgency(item1, item2) {
-	//gets the days until next purchase between current date and dateNextPurchased for item argument
+	//Declare current date
+	const currentDate = new Date();
+
+	//Returns the days until next purchase between currentDate and dateNextPurchased for item argument
 	function getDaysUntilNextPurchase(item) {
-		return getDaysBetweenDates(new Date(), item.dateNextPurchased.toDate());
+		return getDaysBetweenDates(currentDate, item.dateNextPurchased.toDate());
 	}
 
 	//Inactive item conditional
@@ -47,9 +50,9 @@ export function comparePurchaseUrgency(item1, item2) {
 		return 1;
 	}
 	//Overdue item conditional
-	if (new Date() > item1.dateNextPurchased.toDate()) {
+	if (currentDate > item1.dateNextPurchased.toDate()) {
 		return -1;
-	} else if (new Date() > item2.dateNextPurchased.toDate()) {
+	} else if (currentDate > item2.dateNextPurchased.toDate()) {
 		return 1;
 	}
 	//Conditionals for days until next purchase and alphabetized if same number of days
@@ -60,6 +63,8 @@ export function comparePurchaseUrgency(item1, item2) {
 	) {
 		return 1;
 	} else {
+		// if days until next purchase between item1 and item2 are the same,
+		// we return the item earlier in the alphabet
 		if (item1.name < item2.name) {
 			return -1;
 		} else {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -52,9 +52,13 @@ export function comparePurchaseUrgency(item1, item2) {
 	//Overdue item conditional
 	if (currentDate > item1.dateNextPurchased.toDate()) {
 		return -1;
-	} else if (currentDate > item2.dateNextPurchased.toDate()) {
+	} else if (
+		currentDate > item2.dateNextPurchased.toDate() &&
+		getDaysUntilNextPurchase(item2) < 60
+	) {
 		return 1;
 	}
+
 	//Conditionals for days until next purchase and alphabetized if same number of days
 	if (getDaysUntilNextPurchase(item1) < getDaysUntilNextPurchase(item2)) {
 		return -1;

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -30,6 +30,42 @@ export function streamListItems(listId, handleSuccess) {
 }
 
 /**
+ * comparePurchaseUrgency
+ * sorts inactive items last, then
+ * sorts items in ascending order of days until purchase, and
+ * sorts items with the same days until purchase alphabetically
+ */
+export function comparePurchaseUrgency(dateNextPurchased) {
+	//take in an item value for date next purchased
+
+	//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
+	const currentDate = new Date();
+	const daysSinceLastPurchased = getDaysBetweenDates(
+		currentDate,
+		dateNextPurchased.toDate(),
+	);
+	console.log('Days since last purchased = ', daysSinceLastPurchased);
+	let buyingUrgency;
+
+	//if else statement to declare which of the 4 possible groups of urgency it belongs to
+	if (daysSinceLastPurchased <= 7) {
+		buyingUrgency = 'soon (7 days or less)';
+	} else if (7 < daysSinceLastPurchased < 30) {
+		buyingUrgency = 'kind of soon (30 days or less)';
+	} else if (daysSinceLastPurchased >= 30) {
+		buyingUrgency = 'not soon (more than 30 days)';
+	} else if (30 < daysSinceLastPurchased < 60) {
+		buyingUrgency = 'overdue for purchase';
+	} else {
+		buyingUrgency = 'inactive (has not been purchased recently)';
+	}
+
+	//return urgency value
+
+	return buyingUrgency;
+}
+
+/**
  * Read the information from the provided snapshot and return an array
  * that can be stored in our React state.
  * @param {Object} snapshot A special Firebase document with information about the current state of the database.

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -32,11 +32,9 @@ export function streamListItems(listId, handleSuccess) {
 /**
  * comparePurchaseUrgency CURRENT FUNCTIONS:
  * - sort for inactive items last, then
- * - sort to most urgent date next pruchased, then
- * - sorts to earliest alphabet name if date next purchased is the same
- *
- * TODO (STRETCH GOAL):
- * - sorts for overdue items to be listed at the top that aren't inactive
+ * - sort for overdue items to be listed at the top that aren't inactive, then
+ * - sort to most urgent date next purchased, then
+ * - sort to earliest alphabet name if date next purchased is the same
  */
 export function comparePurchaseUrgency(item1, item2) {
 	//gets the days until next purchase between current date and dateNextPurchased for item argument

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -38,7 +38,7 @@ export function streamListItems(listId, handleSuccess) {
  * - sort to earliest alphabet name if date next purchased is the same
  */
 export function comparePurchaseUrgency(item1, item2) {
-	//Declare current date
+	//Declare current date and inactive days
 	const currentDate = new Date();
 
 	//Returns the days until next purchase between currentDate and dateNextPurchased for item argument

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -36,10 +36,23 @@ export function streamListItems(listId, handleSuccess) {
  * sorts items with the same days until purchase alphabetically
  */
 
-//TODO: include sort for inactive items last
-// IT DOES:  - sort to most urgent date next pruchased
+// IT DOES:  - sort for inactive items last, then
+//			 - sort to most urgent date next pruchased, then
 // 			 - sorts to earliest alphabet name if date next purchased is the same
 export function comparePurchaseUrgency(item1, item2) {
+	//inactive items got last immediately
+	const daysSinceLastPurchasedItem1 = getDaysBetweenDates(
+		new Date(),
+		item1.dateNextPurchased.toDate(),
+	);
+
+	if (daysSinceLastPurchasedItem1 >= 60) {
+		return 1;
+	}
+	// if (daysSinceLastPurchasedItem1 < 60 && daysSinceLastPurchasedItem1 > 30) {
+	// 	return -1;
+	// }
+
 	if (item1.dateNextPurchased.toDate() < item2.dateNextPurchased.toDate()) {
 		return -1;
 	} else if (
@@ -54,29 +67,6 @@ export function comparePurchaseUrgency(item1, item2) {
 		}
 	}
 }
-
-//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
-// const daysSinceLastPurchased = getDaysBetweenDates(
-// 	currentDate,
-// 	item.dateNextPurchased.toDate(),
-// );
-// console.log(daysSinceLastPurchased);
-// let buyingUrgency;
-
-//if else statement to declare which of the 4 possible groups of urgency it belongs to
-// if (daysSinceLastPurchased <= 7) {
-// 	buyingUrgency = 'soon (7 days or less)';
-// } else if (7 < daysSinceLastPurchased < 30) {
-// 	buyingUrgency = 'kind of soon (30 days or less)';
-// } else if (daysSinceLastPurchased >= 30) {
-// 	buyingUrgency = 'not soon (more than 30 days)';
-// } else if (30 < daysSinceLastPurchased < 60) {
-// 	buyingUrgency = 'overdue for purchase';
-// } else {
-// 	buyingUrgency = 'inactive (has not been purchased recently)';
-// }
-
-//return urgency value
 
 /**
  * Read the information from the provided snapshot and return an array

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -46,7 +46,7 @@ export function ListItem({
 		});
 	};
 
-	//Function to return the buying urgency tag associated with an item
+	//Function to assign string value to buyingUrgency and color value to colorUrgency
 	const getBuyingUrgency = () => {
 		//Returns the difference between the currentDate and dateNextPurchased
 		const daysUntilNextPurchase = getDaysBetweenDates(
@@ -79,7 +79,9 @@ export function ListItem({
 	};
 
 	if (name) {
+		//call on function getBuyingUrgency get the correct urgency attributes
 		getBuyingUrgency();
+
 		return (
 			<li className="ListItem">
 				<label>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -55,23 +55,11 @@ export function ListItem({
 			dateNextPurchased.toDate(),
 		);
 
-		/**
-		 * TODO: STRETCH GOAL: (overdue)
-		 * 	- Extend the functionality of comparePurchaseUrgency to sort “overdue” items to the top of the list
-		 *	- Indicate in your UI when an item is overdue
-		 * QUESTION:
-		 * 	What shows date next purchase has passed? To be placed in conditional below
-		 */
-		let daysSinceLastPurchase = dateLastPurchased
-			? getDaysBetweenDates(
-					dateNextPurchased.toDate(),
-					dateLastPurchased.toDate(),
-			  )
-			: dateLastPurchased;
-
 		//if else statement to declare which of the 4 possible groups of urgency it belongs to
 		if (daysUntilNextPurchase >= 60) {
 			buyingUrgency = 'inactive (has not been purchased recently)';
+		} else if (new Date() > dateNextPurchased.toDate()) {
+			buyingUrgency = 'overdue';
 		} else if (daysUntilNextPurchase >= 30) {
 			buyingUrgency = 'not soon (more than 30 days)';
 		} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -10,6 +10,7 @@ export function ListItem({
 	dateNextPurchased,
 }) {
 	const [check, setCheck] = useState(false);
+	const currentDate = new Date();
 
 	/**
 	 * When List view is opened or refreshed,
@@ -18,7 +19,6 @@ export function ListItem({
 	 * was purchased fewer than 24 hours ago.
 	 */
 	useEffect(() => {
-		const currentDate = new Date();
 		/*  purchaseDate is filtering for dates that exists in the Firestore shopping list collection
 		 And if date exists, it's converting it to a JavaScript timestamp */
 		let purchasedDate = dateLastPurchased
@@ -45,20 +45,19 @@ export function ListItem({
 
 	//Function to return the buying urgency tag associated with an item
 	const getBuyingUrgency = () => {
-		//declare value for buying urgency string to be returned
+		//Declare value for buying urgency string to be returned
 		let buyingUrgency;
 
-		//Use getDaysBetweenDates to find the difference between the current date and dateNextPurchased
-		//Note - this doesn't specify yet whether a dateNextPurchase date has passed
+		//Returns the difference between the currentDate and dateNextPurchased
 		const daysUntilNextPurchase = getDaysBetweenDates(
-			new Date(),
+			currentDate,
 			dateNextPurchased.toDate(),
 		);
 
-		//if else statement to declare which of the 4 possible groups of urgency it belongs to
+		//Conditional statement to declare which of the 4 possible groups of urgency it belongs to
 		if (daysUntilNextPurchase >= 60) {
 			buyingUrgency = 'inactive (has not been purchased recently)';
-		} else if (new Date() > dateNextPurchased.toDate()) {
+		} else if (currentDate > dateNextPurchased.toDate()) {
 			buyingUrgency = 'overdue';
 		} else if (daysUntilNextPurchase >= 30) {
 			buyingUrgency = 'not soon (more than 30 days)';
@@ -67,6 +66,7 @@ export function ListItem({
 		} else {
 			buyingUrgency = 'soon (7 days or less)';
 		}
+
 		return buyingUrgency;
 	};
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -26,7 +26,8 @@ export function ListItem({ name, itemId, dateLastPurchased, urgency }) {
 		Then, the checked value here is passed as a property to `firebase.js` relaying if
 		the number of hours between the purchase date and the current time is less than 1 day
 		*/
-		getDaysBetweenDates(currentDate, purchasedDate) < 1
+
+		getDaysBetweenDates(currentDate, purchasedDate, false) < 1
 			? setCheck(true)
 			: setCheck(false);
 	}, [dateLastPurchased]);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,7 +2,6 @@ import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { useState, useEffect } from 'react';
 import { getDaysBetweenDates } from '../utils/dates';
-import { comparePurchaseUrgency } from '../api/firebase';
 
 export function ListItem({
 	name,
@@ -44,24 +43,35 @@ export function ListItem({
 		});
 	};
 
+	//Function to return the buying urgency tag associated with an item
 	const getBuyingUrgency = () => {
-		//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
+		//declare value for buying urgency string to be returned
+		let buyingUrgency;
+
+		//Use getDaysBetweenDates to find the difference between the current date and dateNextPurchased
+		//Note - this doesn't specify yet whether a dateNextPurchase date has passed
 		const daysUntilNextPurchase = getDaysBetweenDates(
 			new Date(),
 			dateNextPurchased.toDate(),
 		);
 
+		/**
+		 * TODO: STRETCH GOAL: (overdue)
+		 * 	- Extend the functionality of comparePurchaseUrgency to sort “overdue” items to the top of the list
+		 *	- Indicate in your UI when an item is overdue
+		 * QUESTION:
+		 * 	What shows date next purchase has passed? To be placed in conditional below
+		 */
 		let daysSinceLastPurchase = dateLastPurchased
-			? getDaysBetweenDates(new Date(), dateLastPurchased.toDate())
+			? getDaysBetweenDates(
+					dateNextPurchased.toDate(),
+					dateLastPurchased.toDate(),
+			  )
 			: dateLastPurchased;
-
-		let buyingUrgency;
 
 		//if else statement to declare which of the 4 possible groups of urgency it belongs to
 		if (daysUntilNextPurchase >= 60) {
 			buyingUrgency = 'inactive (has not been purchased recently)';
-		} else if (daysUntilNextPurchase > 30 && daysSinceLastPurchase > 0) {
-			buyingUrgency = 'overdue for purchase';
 		} else if (daysUntilNextPurchase >= 30) {
 			buyingUrgency = 'not soon (more than 30 days)';
 		} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {
@@ -73,10 +83,6 @@ export function ListItem({
 	};
 
 	if (name) {
-		/**TEST AD
-		 *
-		 */
-		// let buyingUrgency = comparePurchaseUrgency(dateNextPurchased);
 		return (
 			<li className="ListItem">
 				<label>
@@ -88,7 +94,9 @@ export function ListItem({
 						disabled={check}
 					/>
 					{name}
-					&nbsp; frequency: {getBuyingUrgency()}
+					&nbsp;
+					{/* return buying urgency string */}
+					{getBuyingUrgency()}
 				</label>
 			</li>
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -44,6 +44,34 @@ export function ListItem({
 		});
 	};
 
+	const getBuyingUrgency = () => {
+		//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
+		const daysUntilNextPurchase = getDaysBetweenDates(
+			new Date(),
+			dateNextPurchased.toDate(),
+		);
+
+		let daysSinceLastPurchase = dateLastPurchased
+			? getDaysBetweenDates(new Date(), dateLastPurchased.toDate())
+			: dateLastPurchased;
+
+		let buyingUrgency;
+
+		//if else statement to declare which of the 4 possible groups of urgency it belongs to
+		if (daysUntilNextPurchase >= 60) {
+			buyingUrgency = 'inactive (has not been purchased recently)';
+		} else if (daysUntilNextPurchase > 30 && daysSinceLastPurchase > 0) {
+			buyingUrgency = 'overdue for purchase';
+		} else if (daysUntilNextPurchase >= 30) {
+			buyingUrgency = 'not soon (more than 30 days)';
+		} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {
+			buyingUrgency = 'kind of soon (30 days or less)';
+		} else {
+			buyingUrgency = 'soon (7 days or less)';
+		}
+		return buyingUrgency;
+	};
+
 	if (name) {
 		/**TEST AD
 		 *
@@ -60,7 +88,7 @@ export function ListItem({
 						disabled={check}
 					/>
 					{name}
-					&nbsp; frequency: {'buyingUrgency'}
+					&nbsp; frequency: {getBuyingUrgency()}
 				</label>
 			</li>
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -29,6 +29,8 @@ export function ListItem({ name, itemId, dateLastPurchased, urgency }) {
 		the number of hours between the purchase date and the current time is less than 1 day
 		*/
 
+		// TEST COMMENT //
+
 		getDaysBetweenDates(currentDate, purchasedDate, false) < 1
 			? setCheck(true)
 			: setCheck(false);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,8 +2,14 @@ import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { useState, useEffect } from 'react';
 import { getDaysBetweenDates } from '../utils/dates';
+import { comparePurchaseUrgency } from '../api/firebase';
 
-export function ListItem({ name, itemId, dateLastPurchased }) {
+export function ListItem({
+	name,
+	itemId,
+	dateLastPurchased,
+	dateNextPurchased,
+}) {
 	const [check, setCheck] = useState(false);
 
 	/**
@@ -39,6 +45,10 @@ export function ListItem({ name, itemId, dateLastPurchased }) {
 	};
 
 	if (name) {
+		/**TEST AD
+		 *
+		 */
+		let buyingUrgency = comparePurchaseUrgency(dateNextPurchased);
 		return (
 			<li className="ListItem">
 				<label>
@@ -50,6 +60,7 @@ export function ListItem({ name, itemId, dateLastPurchased }) {
 						disabled={check}
 					/>
 					{name}
+					&nbsp; frequency: {buyingUrgency}
 				</label>
 			</li>
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -29,8 +29,6 @@ export function ListItem({ name, itemId, dateLastPurchased, urgency }) {
 		the number of hours between the purchase date and the current time is less than 1 day
 		*/
 
-		// TEST COMMENT //
-
 		getDaysBetweenDates(currentDate, purchasedDate, false) < 1
 			? setCheck(true)
 			: setCheck(false);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -48,7 +48,7 @@ export function ListItem({
 		/**TEST AD
 		 *
 		 */
-		let buyingUrgency = comparePurchaseUrgency(dateNextPurchased);
+		// let buyingUrgency = comparePurchaseUrgency(dateNextPurchased);
 		return (
 			<li className="ListItem">
 				<label>
@@ -60,7 +60,7 @@ export function ListItem({
 						disabled={check}
 					/>
 					{name}
-					&nbsp; frequency: {buyingUrgency}
+					&nbsp; frequency: {'buyingUrgency'}
 				</label>
 			</li>
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -79,7 +79,7 @@ export function ListItem({
 	};
 
 	if (name) {
-		//call on function getBuyingUrgency get the correct urgency attributes
+		//call on function getBuyingUrgency to assign urgency attributes
 		getBuyingUrgency();
 
 		return (

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,17 +3,10 @@ import { updateItem } from '../api/firebase';
 import { useState, useEffect } from 'react';
 import { getDaysBetweenDates } from '../utils/dates';
 
-export function ListItem({
-	name,
-	itemId,
-	dateLastPurchased,
-	dateNextPurchased,
-}) {
+export function ListItem({ name, itemId, dateLastPurchased, urgency }) {
 	const [check, setCheck] = useState(false);
 	//Declare currentDate, colorUrgency, and buyingUrgency
 	const currentDate = new Date();
-	let colorUrgency;
-	let buyingUrgency;
 
 	/**
 	 * When List view is opened or refreshed,
@@ -46,42 +39,11 @@ export function ListItem({
 		});
 	};
 
-	//Function to assign string value to buyingUrgency and color value to colorUrgency
-	const getBuyingUrgency = () => {
-		//Returns the difference between the currentDate and dateNextPurchased
-		const daysUntilNextPurchase = getDaysBetweenDates(
-			currentDate,
-			dateNextPurchased.toDate(),
-		);
-
-		//Conditional statement to categorize if an item is:
-		// - inactive: (60 days have passed since the last purchase)
-		// - overdue: currentDate has passed the dateNextPurchased, but not yet inactive
-		// - not soon: (30 days or more until the next purchase)
-		// - kind of soon: (between 7 & 30 days until the next purchase)
-		// - soon: (7 days or fewer until the next purchase)
-		if (daysUntilNextPurchase >= 60) {
-			buyingUrgency = 'inactive';
-			colorUrgency = '#878E88';
-		} else if (currentDate > dateNextPurchased.toDate()) {
-			buyingUrgency = 'overdue';
-			colorUrgency = '#A30000';
-		} else if (daysUntilNextPurchase >= 30) {
-			buyingUrgency = 'not soon';
-			colorUrgency = '#004777';
-		} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {
-			buyingUrgency = 'kind of soon';
-			colorUrgency = '#00AFB5';
-		} else {
-			buyingUrgency = 'soon';
-			colorUrgency = '#FF7700';
-		}
-	};
+	/* Checking for the existence of urgency to avoid `undefined` */
+	const buyingUrgency = urgency ? urgency.buyingUrgency : '';
+	const colorUrgency = urgency ? urgency.colorUrgency : '';
 
 	if (name) {
-		//call on function getBuyingUrgency to assign urgency attributes
-		getBuyingUrgency();
-
 		return (
 			<li className="ListItem">
 				<label>
@@ -94,7 +56,7 @@ export function ListItem({
 					/>
 					{name}
 					{/* return buying urgency and temporary color identifiers */}
-					<span style={{ color: `${colorUrgency}` }}> {buyingUrgency}</span>
+					<span style={{ color: colorUrgency }}> {buyingUrgency}</span>
 				</label>
 			</li>
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -10,7 +10,10 @@ export function ListItem({
 	dateNextPurchased,
 }) {
 	const [check, setCheck] = useState(false);
+	//Declare currentDate, colorUrgency, and buyingUrgency
 	const currentDate = new Date();
+	let colorUrgency;
+	let buyingUrgency;
 
 	/**
 	 * When List view is opened or refreshed,
@@ -45,32 +48,38 @@ export function ListItem({
 
 	//Function to return the buying urgency tag associated with an item
 	const getBuyingUrgency = () => {
-		//Declare value for buying urgency string to be returned
-		let buyingUrgency;
-
 		//Returns the difference between the currentDate and dateNextPurchased
 		const daysUntilNextPurchase = getDaysBetweenDates(
 			currentDate,
 			dateNextPurchased.toDate(),
 		);
 
-		//Conditional statement to declare which of the 4 possible groups of urgency it belongs to
+		//Conditional statement to categorize if an item is:
+		// - inactive: (60 days have passed since the last purchase)
+		// - overdue: currentDate has passed the dateNextPurchased, but not yet inactive
+		// - not soon: (30 days or more until the next purchase)
+		// - kind of soon: (between 7 & 30 days until the next purchase)
+		// - soon: (7 days or fewer until the next purchase)
 		if (daysUntilNextPurchase >= 60) {
-			buyingUrgency = 'inactive (has not been purchased recently)';
+			buyingUrgency = 'inactive';
+			colorUrgency = '#878E88';
 		} else if (currentDate > dateNextPurchased.toDate()) {
 			buyingUrgency = 'overdue';
+			colorUrgency = '#A30000';
 		} else if (daysUntilNextPurchase >= 30) {
-			buyingUrgency = 'not soon (more than 30 days)';
+			buyingUrgency = 'not soon';
+			colorUrgency = '#004777';
 		} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {
-			buyingUrgency = 'kind of soon (30 days or less)';
+			buyingUrgency = 'kind of soon';
+			colorUrgency = '#00AFB5';
 		} else {
-			buyingUrgency = 'soon (7 days or less)';
+			buyingUrgency = 'soon';
+			colorUrgency = '#FF7700';
 		}
-
-		return buyingUrgency;
 	};
 
 	if (name) {
+		getBuyingUrgency();
 		return (
 			<li className="ListItem">
 				<label>
@@ -82,9 +91,8 @@ export function ListItem({
 						disabled={check}
 					/>
 					{name}
-					&nbsp;
-					{/* return buying urgency string */}
-					{getBuyingUrgency()}
+					{/* return buying urgency and temporary color identifiers */}
+					<span style={{ color: `${colorUrgency}` }}> {buyingUrgency}</span>
 				</label>
 			</li>
 		);

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -17,7 +17,8 @@ export function getDaysBetweenDates(date1, date2) {
 	the absolute value of their difference in milliseconds. */
 	const timeElapsed = Math.abs(date1 - date2);
 
-	/* daysElapsed converts the milliseconds of timeElapsed into days */
-	const daysElapsed = timeElapsed / ONE_DAY_IN_MILLISECONDS;
+	/* daysElapsed converts the milliseconds of timeElapsed into days 
+	and rounds the up that number  */
+	const daysElapsed = Math.ceil(timeElapsed / ONE_DAY_IN_MILLISECONDS);
 	return daysElapsed;
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -18,7 +18,7 @@ export function getDaysBetweenDates(date1, date2, roundDays = true) {
 	const timeElapsed = Math.abs(date1 - date2);
 
 	/* daysElapsed converts the milliseconds of timeElapsed into days 
-	and rounds the up that number  */
+	and rounds up that number  */
 	const daysElapsed = timeElapsed / ONE_DAY_IN_MILLISECONDS;
 
 	return roundDays ? Math.ceil(daysElapsed) : daysElapsed;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,13 +12,14 @@ export function getFutureDate(offset) {
 }
 
 /** This function returns the number of days elapsed between two JavaScript Dates*/
-export function getDaysBetweenDates(date1, date2) {
+export function getDaysBetweenDates(date1, date2, roundDays = true) {
 	/* The time elapsed between two dates is found by getting 
 	the absolute value of their difference in milliseconds. */
 	const timeElapsed = Math.abs(date1 - date2);
 
 	/* daysElapsed converts the milliseconds of timeElapsed into days 
 	and rounds the up that number  */
-	const daysElapsed = Math.ceil(timeElapsed / ONE_DAY_IN_MILLISECONDS);
-	return daysElapsed;
+	const daysElapsed = timeElapsed / ONE_DAY_IN_MILLISECONDS;
+
+	return roundDays ? Math.ceil(daysElapsed) : daysElapsed;
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,6 +2,7 @@ import { ListItem } from '../components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
+import { getDaysBetweenDates } from '../utils/dates';
 
 /** List component that displays items in a user's shopping cart  */
 export function List({ data, loading }) {
@@ -9,9 +10,23 @@ export function List({ data, loading }) {
 	const [filterInput, setFilterInput] = useState('');
 
 	// **** TEST
-	// const listId = localStorage.getItem('tcl-shopping-list-token');
-	// console.log(listId);
-	// comparePurchaseUrgency(listId);
+	const urgencyData = data
+		.filter((item) => item.name)
+		.sort(comparePurchaseUrgency);
+
+	console.log('Urgency sorted data: ', urgencyData);
+	console.log(
+		'ugency data days until next purchase: ',
+		urgencyData.map((item) => {
+			//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
+			const daysSinceLastPurchased = getDaysBetweenDates(
+				new Date(),
+				item.dateNextPurchased.toDate(),
+			);
+			console.log(daysSinceLastPurchased);
+			return item.name + item.dateNextPurchased.toDate();
+		}),
+	);
 
 	/* Declare navigate for view redirection */
 	const navigate = useNavigate();

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -102,7 +102,7 @@ export function List({ data, loading }) {
 				{/* Uses data or state of filteredList depending on state of filterInput */}
 				<ul>
 					{!filterInput
-						? data.map((item) => {
+						? urgencyData.map((item) => {
 								return (
 									<ListItem
 										key={item.id}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -55,13 +55,13 @@ export function List({ data, loading }) {
 				colorUrgency = '#878E88';
 			} else if (new Date() > item.dateNextPurchased.toDate()) {
 				buyingUrgency = 'overdue';
-				colorUrgency = '#A30000';
+				colorUrgency = '#CD001A';
 			} else if (daysUntilNextPurchase >= 30) {
 				buyingUrgency = 'not soon';
-				colorUrgency = '#004777';
+				colorUrgency = '#00AFB5';
 			} else if (daysUntilNextPurchase > 7 && daysUntilNextPurchase < 30) {
 				buyingUrgency = 'kind of soon';
-				colorUrgency = '#00AFB5';
+				colorUrgency = '#FFB81C';
 			} else {
 				buyingUrgency = 'soon';
 				colorUrgency = '#FF7700';

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,11 +1,17 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { comparePurchaseUrgency } from '../api/firebase';
 
 /** List component that displays items in a user's shopping cart  */
 export function List({ data, loading }) {
 	const [filteredList, setFilteredList] = useState([]);
 	const [filterInput, setFilterInput] = useState('');
+
+	// **** TEST
+	// const listId = localStorage.getItem('tcl-shopping-list-token');
+	// console.log(listId);
+	// comparePurchaseUrgency(listId);
 
 	/* Declare navigate for view redirection */
 	const navigate = useNavigate();
@@ -88,6 +94,7 @@ export function List({ data, loading }) {
 										itemId={item.id}
 										name={item.name}
 										dateLastPurchased={item.dateLastPurchased}
+										dateNextPurchased={item.dateNextPurchased}
 									/>
 								);
 						  })
@@ -98,6 +105,7 @@ export function List({ data, loading }) {
 										itemId={item.id}
 										name={item.name}
 										dateLastPurchased={item.dateLastPurchased}
+										dateNextPurchased={item.dateNextPurchased}
 									/>
 								);
 						  })}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -73,11 +73,11 @@ export function List({ data, loading }) {
 
 	/* Sorting the shopping list items by urgency */
 	let dataWithUrgency = data
+		.filter((item) => item.hasOwnProperty('name'))
 		.map((item) => ({
 			...item,
 			urgency: getBuyingUrgency(item),
 		}))
-		.filter((item) => item.hasOwnProperty('name'))
 		.sort(comparePurchaseUrgency);
 
 	/* Use handler to change the state of filterInput 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -34,10 +34,11 @@ export function List({ data, loading }) {
 
 	//Function to assign string value to buyingUrgency and color value to colorUrgency
 	const getBuyingUrgency = (item) => {
-		//Returns the difference between the currentDate and dateNextPurchased
 		let buyingUrgency;
 		let colorUrgency;
 
+		//To filter for non-empty items, if an item exists in the data and has a
+		//dateNextPurchased value, that item will be assigned a daysUntilNextPurchase value.
 		if (item.dateNextPurchased) {
 			let daysUntilNextPurchase = getDaysBetweenDates(
 				new Date(),
@@ -68,10 +69,16 @@ export function List({ data, loading }) {
 			}
 		}
 
+		//To be used as new additions to item properties in the new shopping list dataWithUrgency
 		return { buyingUrgency, colorUrgency };
 	};
 
-	/* Sorting the shopping list items by urgency */
+	/* Sorting the shopping list items by urgency using the following steps:
+		- filter() to use items that are non-empty
+		- map() to create a new array using the existing shopping items ,
+			and adding the urgency properties of buyingUrgency and colorUrgency to urgency key.
+		- sort() to utilize the comparePurchaseUrgency function created in firebase to sort items by urgency
+	*/
 	let dataWithUrgency = data
 		.filter((item) => item.hasOwnProperty('name'))
 		.map((item) => ({

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -9,24 +9,10 @@ export function List({ data, loading }) {
 	const [filteredList, setFilteredList] = useState([]);
 	const [filterInput, setFilterInput] = useState('');
 
-	// **** TEST
+	/* Sorted shopping list data by purchase urgency */
 	const urgencyData = data
 		.filter((item) => item.name)
 		.sort(comparePurchaseUrgency);
-
-	console.log('Urgency sorted data: ', urgencyData);
-	console.log(
-		'ugency data days until next purchase: ',
-		urgencyData.map((item) => {
-			//Use getDaysBetweenDates to find the difference between dateLastPurchased and dateNextPurchased
-			const daysSinceLastPurchased = getDaysBetweenDates(
-				new Date(),
-				item.dateNextPurchased.toDate(),
-			);
-			console.log(daysSinceLastPurchased);
-			return item.name + item.dateNextPurchased.toDate();
-		}),
-	);
 
 	/* Declare navigate for view redirection */
 	const navigate = useNavigate();
@@ -102,7 +88,8 @@ export function List({ data, loading }) {
 				{/* Uses data or state of filteredList depending on state of filterInput */}
 				<ul>
 					{!filterInput
-						? urgencyData.map((item) => {
+						? // map over the sorted urgencyData
+						  urgencyData.map((item) => {
 								return (
 									<ListItem
 										key={item.id}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,7 +2,6 @@ import { ListItem } from '../components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api/firebase';
-import { getDaysBetweenDates } from '../utils/dates';
 
 /** List component that displays items in a user's shopping cart  */
 export function List({ data, loading }) {


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

### Task:
To have the UI show the user how urgent each item needs to be purchased. Item status can be:
- `Overdue`: You should buy this item soon since it's pass your estimated purchase date and is not yet inactive.
- `Soon`: You've got 7 days or fewer until the *next* estimated purchase date. Purchase it soon!
- `Kind of Soon`: You've got between 7 & 30 days until the *next* estimated purchase date. Purchase it soon-ish!
- `Not Soon`: You've still got 30 days or more until the *next* estimated purchase date. No need to purchase right away.
- `Inactive`: You have not purchased this in 60 days.

## Our current implementation:

#### Note: Much of the following logic explained here have been modified/refactored.

### Client-side:

#### `ListItem.jsx`

**Update:** This has since been updated and the functionality has been moved to `List.jsx`

**Old way:**
-  In the function `getBuyingUrgency`, we create conditionals to reflect the correct tags and temporary color urgency attributes for our items. 
   - For example, the conditional `if (daysUntilNextPurchase) >= 60` means it's been 60 or more days since the estimated next purchase, so the tag "Inactive (has not been purchased recently" will be shown for that item. Same logic goes for the rest of the purchase urgency.
- To get the value of the aforementioned `dayUntilNextPurchase`, the `getDaysBetweenDates` function from `utils` is imported and used to calculate the interval between today and `dateNextPurchased` property.
- We call on `getBuyingUrgency()` on line 83 to assign the value of which will be whatever is the appropriate color and string value associated with the item.

#### `List.jsx`

**Update:** This function (`urgencyData`) has been updated to match the logic of `getBuyingUrgency` which has now been moved from `ListItem` to `List`

**Old way:**
- Have a look at `urgencyData`, in we which filter through our `data` for the names of the items. Now that we have the names, we `sort` through them based on a _**function**_ that defines the sort order. The set of instructions inside this function `comparePurchaseUrgency` tell us the order in which the items should be organized (soon, not soon, etc). 
- `comparePurchaseUrgency` is defined in `firebase.js`.
- On line 91 we no longer map the originally pulled `data` for our list items, and instead use the correctly sorted order of our shopping list from `urgencyData`

### Server-side:

**Update:** Changes have been made to `comparePurchaseUrgency` to account for accurate alphabetization of the items.

#### `firebase.js`

- `comparePurchaseUrgency` function: It's taking two parameters, `item1` and `item2`. In this compare function we are comparing one element (first item) with another element (second item). The comparison determines which one of the two will go first in the list. The function does this for all the names on the list. It essentially "walks" through the list of names we retrieved earlier, and sorts everything according to the conditionals in place. At the end of all this, the expected result is that everything should be ordered based on their urgency.
- Conditionals from `comparePurchaseUrgency`:
```
  if (item1.dateNextPurchased.toDate() < item2.dateNextPurchased.toDate()) {
		    return -1;
	    } else if (
		    item1.dateNextPurchased.toDate() > item2.dateNextPurchased.toDate()
	    ) {
		    return 1;
	    } 
          / *... */
    };
```
We're highlighting some of the code to draw attention to the return value, but please refer to the files for a better look at the entire block of code. 

**Refresher:** Remember that `dateNextPurchased` is a document property in Firestore. We are using a `toDate()` function to convert it to a date that JavaScript can read. Because Firestore dates are...quirky. 🤷🏽‍♀️

   - Note in the code block that there is a `return -1` and a `return 1`. The negative or positive value determines the placement of the items on the list.
      - If the `dateNextPurchased` of `item1` is less than the `dateNextPurchased` of `item2`, then `item1` is placed _**before**_ `item2` on the shopping list (hence `-1`).
      - If the opposite is true -- `item1`'s `dateNextPurchased` is _greater than_ `item2`'s -- then `item1` is placed **_after_** `item2` on the shopping list (hence `1`).
      - This is how the compare function works when we `sort`. See the table in the **"Description"** section of this [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description). 

You may or may not be wondering, where are these return values being used? If you recall, in `List.jsx` earlier, we had the `urgencyData` in which we filter and sort the list. We have now passed the return value of `comparePurchaseUrgency` (`-1` or `1`) to the `sort` method, and our list (`urgencyData`) is now expected to be in order of their urgency.

#### `dates.js`
- We rounded up the returned `daysElapsed` with `Math.ceil` so that the comparison value of the days didn't include decimal values, but a rounded number we can use while sorting comparisons in `firebase.js`

## Todos

~~Figuring out the logic to account for an "overdue" item. (See stretch goals)~~

## Related Issue
Closes #12

## Acceptance Criteria

- [x] Items in the list are shown with an indicator that tells the user they should buy the item “soon”, “kind of soon”, or “not soon”; or that the item is “inactive”
	- [x] This urgency indicator *does not* rely on only color
- [x] `api/firestore.js` exports a new `comparePurchaseUrgency` function with the following behaviors
	- [x] sorts inactive items last, then
	- [x] sorts items in ascending order of days until purchase, and
	- [x] sorts items with the same days until purchase alphabetically

### Stretch goal
If you complete all of the previous acceptance criteria, consider what happens when an item’s `dateNextPurchased` has passed, but it isn’t yet inactive. Let’s call that item “overdue”.

- [x] Extend the functionality of `comparePurchaseUrgency` to sort “overdue” items to the top of the list
- [x] Indicate in your UI when an item is overdue

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |


## Updates

### Before

![image](https://user-images.githubusercontent.com/89554728/219322086-11c96cbf-4ebe-4715-88eb-efc5d3424a09.png)

### After

![image](https://user-images.githubusercontent.com/89554728/219322142-1522e5c6-80a9-4893-b73d-3184c62ba1e1.png)

## Testing Steps / QA Criteria

1. From your terminal, first run `git pull` and then `git checkout ac-ad-ui-to-display-item-purchasing-urgency`.
2. Next, run `npm start` to open http://localhost:3000/.
3. Create or join a shopping list.
4. Add a new items to the list and manipulate the dates in [Firebase](https://console.firebase.google.com/u/0/project/tcl-54-smart-shopping-list/firestore/data/~2Fburl%20swirl%20ahem~2FiPIevLRFXvR3vA4PtuY1) to confirm if an item is due to be purchased and is categorized correctly: overdue, soon, kind of soon, not soon, or inactive.
5. Items are alphabetized only if they have the **exact** amount of days until the next purchase date, otherwise they are sorted by soonest to be purchased at the top and latest at the bottom. Overdue items are not alphabetized if they have the exact same amount of days since `dateLastPurchased`.

- Note: The color display and UI of the urgency is only temporary here until we decide as a team what style we'd like to move forward with for categorizing items 🌟
