### PR TITLE
Issue 15 | Exit List and routing to Home - ac

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"build": "vite build",
 		"test": "vitest",
 		"preview": "vite preview",
-		"prepare": "husky install"
+		"prepare": "husky install",
+		"host": "vite --host"
 	},
 	"lint-staged": {
 		"*.{js,jsx}": [

--- a/src/components/NavbarShoppingList.jsx
+++ b/src/components/NavbarShoppingList.jsx
@@ -11,6 +11,12 @@ export function NavbarShoppingList() {
 						<Nav.Link href="/">Home</Nav.Link>
 						<Nav.Link href="/list">List</Nav.Link>
 						<Nav.Link href="/add-item">Add Item</Nav.Link>
+						<Nav.Link
+							href="/"
+							onClick={() => localStorage.removeItem('tcl-shopping-list-token')}
+						>
+							Exit List
+						</Nav.Link>
 					</Nav>
 				</Navbar.Collapse>
 			</Container>

--- a/src/components/NavbarShoppingList.jsx
+++ b/src/components/NavbarShoppingList.jsx
@@ -1,6 +1,10 @@
 import { Container, Nav, Navbar } from 'react-bootstrap';
+import { useLocation } from 'react-router';
 
 export function NavbarShoppingList() {
+	// useLocation hook is used to access the current route
+	const location = useLocation();
+
 	return (
 		<Navbar fluid="md" bg="light" expand="lg">
 			<Container>
@@ -11,12 +15,18 @@ export function NavbarShoppingList() {
 						<Nav.Link href="/">Home</Nav.Link>
 						<Nav.Link href="/list">List</Nav.Link>
 						<Nav.Link href="/add-item">Add Item</Nav.Link>
-						<Nav.Link
-							href="/"
-							onClick={() => localStorage.removeItem('tcl-shopping-list-token')}
-						>
-							Exit List
-						</Nav.Link>
+
+						{/* This will make 'Exit List' visible ONLY when route is on /list */}
+						{location.pathname === '/list' ? (
+							<Nav.Link
+								href="/"
+								onClick={() =>
+									localStorage.removeItem('tcl-shopping-list-token')
+								}
+							>
+								Exit List
+							</Nav.Link>
+						) : null}
 					</Nav>
 				</Navbar.Collapse>
 			</Container>


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
When the user is in List view, an Exit List link on the nav bar will be visible. Clicking on this Exit List will remove the list token from local storage and lead the user back to the Home view. 

In `NavBarShoppingList.jsx`, the `useLocation` hook is imported from React Router. This allows us to get access to the `location` object, which contains information about the current route. In this case, `location.pathname` is going to be useful.

In the return statement, "Exit List" is conditionally rendered in the navbar only when `location.pathname` is `/list`. The user will only see this link when they are in the List page.

Additionally, an `onClick` event is added to this exit link so that when it is clicked, the `tcl-shopping-list-token` key is removed from the local storage, effectively exiting the user out of the list.

## Related Issue

Closes #36 

## Acceptance Criteria

- [x] Add Exit List on navbar or when burger menu is clicked
   - [x] Delete list from local storage
   - [x] Route back to the home page
   - [x] "Exit List" link in the navigation is only visible when user in on List view

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |
|   ✓   | :hammer: Refactoring       |

## UI

<img src="https://user-images.githubusercontent.com/102492480/221078450-00cd4377-3342-45bb-8531-ecd48c8fd68d.gif" width="300">


## Testing Steps / QA Criteria

1. From your terminal, first run `git pull` on main and then `git checkout ac-exit-list-and-home-routing`
2. Finally, run npm start to open http://localhost:3000/
3. Check the navbar on each app route (Home, List, Add Item)
