### PR TITLE
Issue 25 | Oven styling mobile viewport fit - ad

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -82,10 +82,11 @@ export function ListItem({ name, itemId, dateLastPurchased, urgency }) {
 						<Form.Check
 							value={name}
 							type="checkbox"
+							label={name}
 							onChange={handleCheck}
 							checked={check}
 							disabled={check}
-							label={name}
+							aria-label="Checkbox for following shopping item"
 						/>
 					</Form>
 					<div>

--- a/src/components/NavbarShoppingList.jsx
+++ b/src/components/NavbarShoppingList.jsx
@@ -10,7 +10,11 @@ export function NavbarShoppingList() {
 		<Navbar expand="lg" className="navbar-custom">
 			<Container className="justify-content-center">
 				<Navbar.Brand href="/list">
-					<Image src={appLogo} className="app-logo-navbar" />
+					<Image
+						src={appLogo}
+						className="app-logo-navbar"
+						alt="Knead to Buy app logo that is a characterized bread bun waving happily"
+					/>
 					Knead to Buy
 				</Navbar.Brand>
 				<Navbar.Toggle aria-controls="basic-navbar-nav" className="border-0" />

--- a/src/components/NavbarShoppingList.jsx
+++ b/src/components/NavbarShoppingList.jsx
@@ -7,18 +7,15 @@ export function NavbarShoppingList() {
 	const location = useLocation();
 
 	return (
-		<Navbar fluid="md" expand="lg" className="navbar-custom">
-			<Container fluid className="m-0  justify-content-center">
-				<Navbar.Brand href="/" className="d-flex align-items-center">
-					<div className="logo-text-container d-flex align-items-center">
-						<Image src={appLogo} className="app-logo-navbar" />
-						<span className="app-name">Knead to Buy</span>
-					</div>
+		<Navbar expand="lg" className="navbar-custom">
+			<Container className="justify-content-center">
+				<Navbar.Brand href="/list">
+					<Image src={appLogo} className="app-logo-navbar" />
+					Knead to Buy
 				</Navbar.Brand>
-				<Navbar.Toggle aria-controls="basic-navbar-nav" />
+				<Navbar.Toggle aria-controls="basic-navbar-nav" className="border-0" />
 				<Navbar.Collapse id="basic-navbar-nav">
 					<Nav className="me-auto text-center">
-						<Nav.Link href="/">Home</Nav.Link>
 						<Nav.Link href="/list">List</Nav.Link>
 						<Nav.Link href="/add-item">Add Items</Nav.Link>
 

--- a/src/index.css
+++ b/src/index.css
@@ -112,11 +112,11 @@ img {
 	}
 
 	.filled-list-view .card {
-		width: 60%;
+		width: 65%;
 	}
 
 	.empty-list-view .card {
-		width: 60%;
+		width: 65%;
 	}
 
 	.filled-list-view .search-bar {

--- a/src/index.css
+++ b/src/index.css
@@ -96,12 +96,8 @@ img {
 
 /* small tablets & ipad styles - NAVBAR SPECIFIC */
 @media screen and (max-width: 600px) {
-	.navbar-custom .container-fluid {
-		flex-direction: column;
-	}
-
-	.navbar-custom .logo-text-container {
-		justify-content: center;
+	.app-logo-navbar {
+		max-width: 2.375rem;
 	}
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,10 @@ img {
 	.app-logo-navbar {
 		max-width: 2.375rem;
 	}
+
+	.navbar-custom {
+		position: sticky;
+	}
 }
 
 /* small tablets & ipad styles */

--- a/src/styles/Layout.css
+++ b/src/styles/Layout.css
@@ -65,9 +65,10 @@
 .List {
 	display: flex;
 	flex-direction: column;
+	justify-content: center;
 	margin: 0 auto;
 	max-width: 100vw;
-	padding-top: calc(3rem + env(safe-area-inset-top, 1rem));
+	padding-top: calc(1.5rem + env(safe-area-inset-top, 1rem));
 	padding-bottom: calc(1rem + env(safe-area-inset-bottom, 1rem));
 	width: 54rem;
 }
@@ -82,7 +83,6 @@
 	padding-left: 1%;
 }
 .List-header h1 {
-	padding-bottom: 3%;
 	font-family: 'Lustria', serif;
 }
 

--- a/src/styles/List.css
+++ b/src/styles/List.css
@@ -74,8 +74,8 @@
 
 .filled-list-view .item-card {
 	margin: auto;
-	padding-bottom: 0.938rem;
-	width: 100%;
+	padding-bottom: calc(0.2rem + 1.5625vw);
+	width: 95%;
 	border-radius: 0.313rem;
 }
 
@@ -94,4 +94,8 @@
 	width: 10.625rem;
 	margin-top: 20%;
 	margin-bottom: 5%;
+}
+
+.filled-list-view .item-not-found p {
+	font-weight: 600;
 }

--- a/src/styles/List.css
+++ b/src/styles/List.css
@@ -50,13 +50,13 @@
 /* Filled shopping list view CSS */
 .filled-list-view .search-bar {
 	margin: auto;
-	width: 18rem;
+	width: calc(17rem + 1.5vw);
 	padding-top: 0.938rem;
 	padding-bottom: 0.938rem;
 }
 
 .filled-list-view .card {
-	width: 9;
+	width: 99%;
 	border: 0;
 	background-color: transparent;
 	margin: auto;
@@ -75,7 +75,7 @@
 .filled-list-view .item-card {
 	margin: auto;
 	padding-bottom: 0.938rem;
-	width: 95%;
+	width: 100%;
 	border-radius: 0.313rem;
 }
 

--- a/src/styles/List.css
+++ b/src/styles/List.css
@@ -99,3 +99,8 @@
 .filled-list-view .item-not-found p {
 	font-weight: 600;
 }
+
+.form-check-input:disabled ~ .form-check-label,
+.form-check-input[disabled] ~ .form-check-label {
+	opacity: 1;
+}

--- a/src/styles/List.css
+++ b/src/styles/List.css
@@ -56,7 +56,7 @@
 }
 
 .filled-list-view .card {
-	width: 100%;
+	width: 9;
 	border: 0;
 	background-color: transparent;
 	margin: auto;
@@ -76,14 +76,6 @@
 	margin: auto;
 	padding-bottom: 0.938rem;
 	width: 95%;
-	border-radius: 0.313rem;
-}
-
-.filled-list-view .add-item-card {
-	margin: auto;
-	width: 95%;
-	background-color: transparent;
-	padding-bottom: 0.938rem;
 	border-radius: 0.313rem;
 }
 

--- a/src/styles/ListItem.css
+++ b/src/styles/ListItem.css
@@ -16,7 +16,7 @@
 	background-color: #e0e0e0;
 }
 
-#plus-item-card h4 {
+#plus-item-card p {
 	background: transparent;
 	border: transparent;
 	color: #495867;
@@ -34,12 +34,18 @@
 	display: inline-block;
 	width: 14.063rem;
 	overflow: hidden;
+	text-align: center;
+}
+
+.filled-list-view .flex-wrap-item-name label {
+	font-weight: 600;
+	color: #495867;
 }
 
 .filled-list-view .flex-center-bread-img {
 	display: flex;
 	justify-content: center;
-	padding-top: 5%;
+	padding-top: 2%;
 }
 
 .filled-list-view .flex-center-bread-img svg {

--- a/src/styles/ListItem.css
+++ b/src/styles/ListItem.css
@@ -30,7 +30,6 @@
 
 .filled-list-view .flex-wrap-item-name {
 	display: flex;
-	flex-wrap: wrap;
 	justify-content: space-between;
 }
 

--- a/src/styles/ListItem.css
+++ b/src/styles/ListItem.css
@@ -38,8 +38,7 @@
 }
 
 .filled-list-view .flex-wrap-item-name label {
-	font-weight: 600;
-	color: #495867;
+	color: #404d5a;
 }
 
 .filled-list-view .flex-center-bread-img {

--- a/src/styles/ListItem.css
+++ b/src/styles/ListItem.css
@@ -12,12 +12,8 @@
 }
 
 #plus-item-card {
-	/* border: 0.15rem dashed #495867; */
 	border: transparent;
-	/* border-width: 0.078rem; */
 	background-color: #e0e0e0;
-	/* background-color: white; */
-	/* background-color: transparent; */
 }
 
 #plus-item-card h4 {

--- a/src/styles/NavbarShoppingList.css
+++ b/src/styles/NavbarShoppingList.css
@@ -11,5 +11,5 @@
 }
 
 .app-logo-navbar {
-	width: 10%;
+	max-width: 10%;
 }

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -114,12 +114,12 @@ export function AddItem({ listToken, data }) {
 
 	return (
 		<>
-			<div className="add-item d-flex flex-column">
+			<div className="add-item d-flex flex-column justify-content-center">
 				<header className="text-center mt-3">
 					<h1 className="fw-bold">Add Item</h1>
 				</header>
 
-				<Container className="add-item-form shadow rounded-3 py-3 mt-5 bg-white">
+				<Container className="add-item-form shadow rounded-3 py-3 mt-2 bg-white">
 					<Form onSubmit={onFormSubmit}>
 						<div className="py-4 mx-5">
 							<Form.Label htmlFor="item">Item Name:</Form.Label>
@@ -228,7 +228,7 @@ export function AddItem({ listToken, data }) {
 						</div>
 					</Form>
 				</Container>
-				<div className="mt-5 w-25 mx-auto ">
+				<div className="mt-4 w-25 mx-auto ">
 					<Croissant />
 				</div>
 			</div>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -129,13 +129,13 @@ export function List({ data, loading }) {
 			<>
 				<div className="item-card">
 					<ListGroupItem
-						className="p-3"
+						className="p-2 mb-2"
 						id="plus-item-card"
 						type="button"
 						label="Add Items"
 						onClick={handleAddItem}
 					>
-						<h4 id="plus-item-button">Add items</h4>
+						<p id="plus-item-button">Add items</p>
 					</ListGroupItem>
 				</div>
 				{
@@ -158,8 +158,11 @@ export function List({ data, loading }) {
 			</>
 		) : filterInput && filteredList.length === 0 ? (
 			<div className="item-not-found">
-				<Image src={confusedBread} />
-				<h4>no matching item found</h4>
+				<Image
+					src={confusedBread}
+					alt="Bread slice character with confused look surrounded by question marks"
+				/>
+				<p>no matching item found</p>
 			</div>
 		) : (
 			filteredList.map((item) => {
@@ -191,7 +194,10 @@ export function List({ data, loading }) {
 					<Card.ImgOverlay>
 						<div className="oven-handle" />
 						<div className="card-overlay-background">
-							<Image src={sadPastry} />
+							<Image
+								src={sadPastry}
+								alt="Pastry character with a sad expression"
+							/>
 							<Card.Title>List is empty.</Card.Title>
 							<Card.Subtitle>
 								Stop loafing around, and start shopping!
@@ -231,7 +237,7 @@ export function List({ data, loading }) {
 						</Form>
 					</div>
 				) : null}
-				{/* conditional will display three options within ListGroup through renderList():
+				{/* conditional in calling `renderList()` will display three options within ListGroup through renderList():
 					- unfiltered shopping list
 					- filtered shopping list
 					- item not found view */}


### PR DESCRIPTION
## Description
### Summary
To optimize the List page display so that the all the elements are shown in the mobile viewport without needing to scroll in most media screens.

### `List.css` and `NavbarShoppingList.css`
The oven SVG and card is already as responsive as it can get, but in order to make it fit the viewport the nav logo, title, and toggle icon are all now in one row rather than two. The margins on the text of the list page tare also updated to make it best fit the mobile view. The padding between list items is also now responsive based on viewport width as. The margins in for the shopping list item card and the add item card in the list view are minimized slightly to fit more items in view for mobile.

The key problem in the navbar was the that the `.app-logo-navbar` width was pushing the toggle icon into the second row with it's current width. To fix this, `width: 10%` is changed to 
`max-width: 10%`. 

### Accessibility
I used Google's Lighthouse feature for adding some missing `alt` and `aria-labels` for accessibility. The opacity of the checked and disabled shopping list item form is brought to `1` for AA color contrast. Note that we'll need to add special SVG alt tags since they aren't caught by Lighthouse's scanner. 

## Related Issue
Closes #56 

## Acceptance Criteria

- [ x ]  Make the oven size responsive depending on the viewport width, especially mobile view
- [ x ]  Make the oven list items and SVGs responsive in relation to the changing oven card

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |

## Updates
### Before
![image](https://user-images.githubusercontent.com/89554728/226131428-46aeeda1-8c0a-4424-8b10-2420d873ca43.png)
![image](https://user-images.githubusercontent.com/89554728/226134106-35dd2376-e869-4719-95c6-2d49eefd940a.png)


### After
![image](https://user-images.githubusercontent.com/89554728/226131440-62597da6-3d7f-41ac-872d-8261eb3daaf3.png)
![image](https://user-images.githubusercontent.com/89554728/226134083-42ba2754-fb9f-44b1-9205-36cf214a4d2d.png)


## Testing Steps / QA Criteria
1. Run `git pull` in your terminal and then `git checkout ad-oven-styling-mobile-viewport-fit`.
2. Run `npm start` and go to http://localhost:3000 and enter a new or existing list.
3. View the list in a mobile view port to confirm that most mobile screens display all the elements in the `List` view.
4. Check with the Google Lighthouse scanner that all the pages meet accessibility needs. Note that the scanner doesn't pick up the SVG React components so a future issue to tackle is adding SVG alt tags.
